### PR TITLE
fix newline handling in webservicestep by using XmlReader.Create

### DIFF
--- a/Src/BizUnit.TestSteps/Soap/WebServiceStep.cs
+++ b/Src/BizUnit.TestSteps/Soap/WebServiceStep.cs
@@ -120,7 +120,7 @@ namespace BizUnit.TestSteps.Soap
                     channel = cf.CreateChannel();
                     using (new OperationContextScope((IContextChannel)channel))
                     {
-                        XmlReader r = new XmlTextReader(requestData);
+                        XmlReader r = XmlReader.Create(requestData);
 
                         request = Message.CreateMessage(MessageVersion.Soap11, action, r);
 


### PR DESCRIPTION
Given an input stream with CRLF in it (XML file loaded with XmlDataLoader) the current implementation had issues with handling newlines. When sending the data to BizTalk the carriage return was entitized.
![image](https://user-images.githubusercontent.com/22931593/53834944-91775900-3f8c-11e9-8192-4390e08c1873.png)

Switching to XmlReader.Create instead of new XmlTextReader the data is sent correctly towards the webservice by removing the CrLf and changing it to Lf (which is according to the [specification](https://www.w3.org/TR/2008/REC-xml-20081126/#sec-line-ends))
![image](https://user-images.githubusercontent.com/22931593/53835047-cedbe680-3f8c-11e9-8e9b-d0190f77a8ff.png)
